### PR TITLE
Make parts be displayed correctly in mac/linux HiDPI

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -6,7 +6,7 @@
 	  	<div>
 	  		<img src='/assets/signpath-logo-white.svg' width="334" height="67" alt='SignPath'/>
 	  		<svg viewBox="0 0 244 18">
-			  <text x="0" y="15">CODE SIGNING SIMPLE &amp; SECURE</text>
+			  <text x="0" y="15" textLenght="244" lengthAdjust="spacingAndGlyphs">CODE SIGNING SIMPLE &amp; SECURE</text>
 			</svg>
 	  		<div>
 				<a target="_blank" href="https://www.linkedin.com/company/33243108" rel="noopener noreferrer">

--- a/docs/_sass/editions.scss
+++ b/docs/_sass/editions.scss
@@ -7,7 +7,7 @@ section.editions {
 
 	div.column-layout {
 		div.features {
-			margin-top: calc(3.65em /* h3 */ - 1em - 20px);
+			margin-top: calc(3.65em /* h3 */ - 1em - 23px);
 		}
 	}
 }

--- a/docs/_sass/product-column-layout.scss
+++ b/docs/_sass/product-column-layout.scss
@@ -18,9 +18,11 @@ div.column-layout {
 				padding: 10px 0.8em;
 				position: relative;
 				box-sizing: border-box;
+				min-height: 50px;
 
 				&.first-after-header {
-					margin-top: calc(1em + 30px);
+					margin-top: 50px;
+					min-height: 50px;
 
 					&.first-after-main-header {
 						margin-top: 0px;


### PR DESCRIPTION
* Footer Logo always displays the full text 
* Editions tables are aligned (downside: always slightly more screen estate used)